### PR TITLE
Typo fixes all around

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For the PDF generation the following steps are performed:
   - the resulting bookmark structure resembles the folder structure
 - optionally place a "Folder PAGE/MAX_PAGES" label to top of each page
 - finally present the generated PDF as download or save it to the
-  cloud file-system.
+  cloud filesystem.
 
 The offers the choice between online and background PDF
 generation. "Background" means that a job is scheduled which then runs

--- a/lib/Controller/MultiPdfDownloadController.php
+++ b/lib/Controller/MultiPdfDownloadController.php
@@ -283,7 +283,7 @@ class MultiPdfDownloadController extends Controller
       try {
         $destinationFolder = $this->getUserFolder()->get($destinationPath);
       } catch (FileNotFoundException $e) {
-        return self::grumble($this->l->t('Unable to open the destination-folder "%s".', $destinationPath));
+        return self::grumble($this->l->t('Unable to open the destination folder "%s".', $destinationPath));
       }
       $nonExistingTarget = $destinationFolder->getNonExistingName($cacheFile->getName());
       $destinationPath = $this->getUserFolderPath()

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -126,7 +126,7 @@ class Notifier implements INotifier
         break;
       case self::TYPE_SUCCESS|self::TYPE_FILESYSTEM:
         $parameters = $notification->getSubjectParameters();
-        $notification->setRichSubject($l->t('Your folder {source} has been converted to a PDF-file at {destination}.'), [
+        $notification->setRichSubject($l->t('Your folder {source} has been converted to a PDF file at {destination}.'), [
           'source' => [
             'type' => 'file',
             'id' => $parameters['sourceId'],
@@ -149,7 +149,7 @@ class Notifier implements INotifier
         break;
       case self::TYPE_SUCCESS|self::TYPE_DOWNLOAD:
         $parameters = $notification->getSubjectParameters();
-        $notification->setRichSubject($l->t('You folder {source} has been converted to a PDF file. Please visit the details-tab of the source-folder to download the file.'), [
+        $notification->setRichSubject($l->t('You folder {source} has been converted to a PDF file. Please visit the details tab of the source folder to download the file.'), [
           'source' => [
             'type' => 'file',
             'id' => $parameters['sourceId'],

--- a/lib/Service/AnyToPdf.php
+++ b/lib/Service/AnyToPdf.php
@@ -287,7 +287,7 @@ class AnyToPdf
       } catch (\Throwable $t) {
         if ($this->builtinConvertersDisabled) {
           throw new RuntimeException(
-            $this->l->t('Universal converter "%1$s" has failed trying to convert mime-type "%2$s"', [
+            $this->l->t('Universal converter "%1$s" has failed trying to convert MIME type "%2$s"', [
               $this->universalConverter, $mimeType,
             ]));
         } else {
@@ -324,7 +324,7 @@ class AnyToPdf
       }
       if (empty($convertedData)) {
         throw new RuntimeException(
-          $this->l->t('Converter "%1$s" has failed trying to convert mime-type "%2$s"', [
+          $this->l->t('Converter "%1$s" has failed trying to convert MIME type "%2$s"', [
             print_r($converter, true), $mimeType,
           ]));
       }

--- a/lib/Service/FileSystemWalker.php
+++ b/lib/Service/FileSystemWalker.php
@@ -353,7 +353,7 @@ __EOF__;
         default:
           throw new Exceptions\Exception(
             $this->l->t(
-              'Internal error, unknown file-system node-type: "%s".',
+              'Internal error, unknown filesystem node type: "%s".',
               $node->getType()
             ));
       }

--- a/lib/Service/FontService.php
+++ b/lib/Service/FontService.php
@@ -234,7 +234,7 @@ class FontService
             $converter = $this->executableFinder->find(self::PDF_TO_SVG);
           } catch (Exceptions\EnduserNotificationException $e) {
             $endUserException = new Exceptions\EnduserNotificationException(
-              $this->l->t('Font-sample could not be generated: %s', $e->getMessage())
+              $this->l->t('Font sample could not be generated: %s', $e->getMessage())
             );
             throw $endUserException;
           }
@@ -251,7 +251,7 @@ class FontService
           $data = file_get_contents($outputFile);
           if (empty($data)) {
             $endUserException = new Exceptions\EnduserNotificationException(
-              $this->l->t('Font-sample could not be generated with "%s".', self::PDF_TO_SVG)
+              $this->l->t('Font sample could not be generated with "%s".', self::PDF_TO_SVG)
             );
             throw $endUserException;
           }
@@ -275,10 +275,10 @@ class FontService
           $data = null;
         }
         if (empty($data)) {
-          $this->logInfo('Font-sample could not be generated with "ImageMagick".');
+          $this->logInfo('Font sample could not be generated with "ImageMagick".');
           if (empty($endUserException)) {
             $endUserException = new Exceptions\EnduserNotificationException(
-              $this->l->t('Font-sample could not be generated with "%s".', 'ImageMagick')
+              $this->l->t('Font sample could not be generated with "%s".', 'ImageMagick')
             );
           }
         }

--- a/src/AdminSettings.vue
+++ b/src/AdminSettings.vue
@@ -52,20 +52,20 @@
                @change="saveSetting('disableBuiltinConverters')"
         >
         <label for="disable-builtin-converters">
-          {{ t(appName, 'Disable the builtin-converters.') }}
+          {{ t(appName, 'Disable the builtin converters.') }}
         </label>
       </div>
       <SettingsInputText
         v-model="universalConverter"
         :label="t(appName, 'Universal Converter')"
-        :hint="t(appName, 'Full path to a filter-program to be executed first for all files. If it fails, the other converters will be tried in turn.')"
+        :hint="t(appName, 'Full path to a filter program to be executed first for all files. If it fails, the other converters will be tried in turn.')"
         :disabled="loading"
         @update="saveTextInput(...arguments, 'universalConverter')"
       />
       <SettingsInputText
         v-model="fallbackConverter"
         :label="t(appName, 'Fallback Converter')"
-        :hint="t(appName, 'Full path to a filter-program to be run when all other filters have failed. If it fails an error page will be substituted for the failing document.')"
+        :hint="t(appName, 'Full path to a filter program to be run when all other filters have failed. If it fails an error page will be substituted for the failing document.')"
         :disabled="loading || builtinConvertersDisabled"
         @update="saveTextInput(...arguments, 'fallbackConverter')"
       />

--- a/src/PersonalSettings.vue
+++ b/src/PersonalSettings.vue
@@ -29,7 +29,7 @@
                @change="saveSetting('pageLabels')"
         >
         <label for="page-labels">
-          {{ t(appName, 'Label output pages with filename and page-number') }}
+          {{ t(appName, 'Label output pages with filename and page number') }}
         </label>
       </div>
       <span class="hint">
@@ -99,7 +99,7 @@
                          max="1.00"
                          step="0.01"
                          :label="t(appName, 'Page label width fraction')"
-                         :hint="t(appName, 'Page label width as decimal fraction of the page-width. Leave empty to use a fixed font-size.')"
+                         :hint="t(appName, 'Page label width as decimal fraction of the page width. Leave empty to use a fixed font size.')"
                          :disabled="loading > 0 || !pageLabels"
                          @update="saveTextInput(...arguments, 'pageLabelPageWidthFraction')"
       />
@@ -109,7 +109,7 @@
                   v-model="pageLabelsFontObject"
                   :placeholder="t(appName, 'Select a Font')"
                   :fonts-list="fontsList"
-                  :label="t(appName, 'Font for generated PDF page-annotations')"
+                  :label="t(appName, 'Font for generated PDF page annotations')"
                   :hint="t(appName, 'The font to use for the page labels: {pageLabelsFont}', { pageLabelsFont })"
                   :disabled="!pageLabels || loading > 0"
                   :loading="loading > 0"
@@ -119,7 +119,7 @@
       <FontSelect v-model="generatedPagesFontObject"
                   :placeholder="t(appName, 'Select a Font')"
                   :fonts-list="fontsList"
-                  :label="t(appName, 'Font for generated PDF (error-)pages')"
+                  :label="t(appName, 'Font for generated PDF (error)pages')"
                   :hint="t(appName, 'The font to use for generated pages: {generatedPagesFont}', { generatedPagesFont })"
                   :disabled="loading > 0"
                   :loading="loading > 0"
@@ -191,7 +191,7 @@
       </SettingsInputText>
       <div class="horizontal-rule" />
       <FilePrefixPicker v-model="pdfCloudFolderFileInfo"
-                        :hint="t(appName, 'Choose a default PDF-file destination folder in the cloud. Leave empty to use the parent directory of the folder which is converted to PDF:')"
+                        :hint="t(appName, 'Choose a default PDF file destination folder in the cloud. Leave empty to use the parent directory of the folder which is converted to PDF:')"
                         :placeholder="t(appName, 'basename')"
                         @update="saveTextInput(pdfCloudFolderPath, 'pdfCloudFolderPath')"
       />
@@ -219,7 +219,7 @@
         <label v-tooltip="tooltips.authenticatedBackgroundJobs"
                for="authenticated-background-jobs"
         >
-          {{ t(appName, 'Use  authenticated background-jobs if necessary.') }}
+          {{ t(appName, 'Use authenticated background jobs if necessary.') }}
         </label>
       </div>
       <div class="horizontal-rule" />
@@ -350,7 +350,7 @@ export default {
       //
       tooltips: {
         useBackgroundJobsDefault: t(appName, 'If checked default to background PDF generation. This can be overridden by navigating to the PDF panel in the details sidebar for each particular source folder or archive file.'),
-        authenticatedBackgroundJobs: t(appName, 'If unsure keep this disabled. Enabling this option leads to an additional directory scan prior to scheduling a background operation. If the scan detects a mount point in the directory which has been mounted with the "authenticated" mount option then your login-credentials will be temporarily promoted to the background job. This is primarily used to handle special cases which should only concern the author of this package. Keep the option disabled unless you really know what it means and you really known that you need it.'),
+        authenticatedBackgroundJobs: t(appName, 'If unsure keep this disabled. Enabling this option leads to an additional directory scan prior to scheduling a background operation. If the scan detects a mount point in the directory which has been mounted with the "authenticated" mount option then your login credentials will be temporarily promoted to the background job. This is primarily used to handle special cases which should only concern the author of this package. Keep the option disabled unless you really know what it means and you really known that you need it.'),
       },
     }
   },
@@ -585,7 +585,7 @@ export default {
             message = responseData.messages.join(' ');
           }
         }
-        showError(t(appName, 'Unable to obtain the pdf-file template example: {message}', {
+        showError(t(appName, 'Unable to obtain the pdf file template example: {message}', {
           message,
         }))
         // can't help, just return the unsubstituted template

--- a/src/views/FilesTab.vue
+++ b/src/views/FilesTab.vue
@@ -100,7 +100,7 @@
         <div class="files-tab-entry__desc"
              @click="showBackgroundDownloads = !showBackgroundDownloads"
         >
-          <h5>{{ t(appName, 'Offline-Downloads') }}</h5>
+          <h5>{{ t(appName, 'Offline Downloads') }}</h5>
         </div>
         <Actions>
           <ActionButton v-model="showBackgroundDownloads"
@@ -224,7 +224,7 @@ export default {
       downloadsTimer: undefined,
       tooltips: {
         pageLabels: t(appName, 'Decorate each page with the original file name and the page number within that file. The default is configured in the personal preferences for the app.'),
-        offline: t(appName, 'When converting many or large files to PDF you will encounter timeouts because the request just lasts too long and the web-server bails out. If this happens you can schedule offline generation of the PDF. This will not make things faster for you, but the execution time is not constrained by the web-server limits. You will be notified when it is ready. If you chose to store the PDF in the cloud file-system, then it will just show up there. If you chose to download to you local computer then the download will show up here (and in the notification). The download links have a configurable expiration time.'),
+        offline: t(appName, 'When converting many or large files to PDF you will encounter timeouts because the request just lasts too long and the web server bails out. If this happens you can schedule offline generation of the PDF. This will not make things faster for you, but the execution time is not constrained by the web server limits. You will be notified when it is ready. If you chose to store the PDF in the cloud filesystem, then it will just show up there. If you chose to download to you local computer then the download will show up here (and in the notification). The download links have a configurable expiration time.'),
         useTemplate: t(appName, 'Auto-generate the download filename from the given template. The default template can be configured in the personal settings for this app.'),
       },
       personalSettings: {},


### PR DESCRIPTION
There are some hyphenated strings all around on the README and on source files that i dare not touch, however, i tried to correct the ones corresponding to direct user messages to avoid any conflicts.

Sorry if this review of the changes takes too long, i'm trying to have some homogeneous structure and proper spacing within those to simplify translation and make any future eventual message modification easier to do.